### PR TITLE
Jesse

### DIFF
--- a/authors.md
+++ b/authors.md
@@ -1,3 +1,4 @@
 - [Ty Dunn](https://github.com/tydunn)
 - [Nate Sesti](https://github.com/sestinj)
 - [Jesse Robbins](https://github.com/jesserobbins)
+- [James Lindenbaum](https://github.com/jnl)

--- a/authors.md
+++ b/authors.md
@@ -1,2 +1,3 @@
 - [Ty Dunn](https://github.com/tydunn)
 - [Nate Sesti](https://github.com/sestinj)
+- [Jesse Robbins](https://github.com/jesserobbins)

--- a/how-to-be-prepared/metrics.md
+++ b/how-to-be-prepared/metrics.md
@@ -1,6 +1,6 @@
 # 3. Measure and improve system metrics
 
-If we want developers to be amplified, they need to understand how the AI software development system works and know if changes they make to it lead to better outcomes or not.
+Amplified developers must understand how the AI software development system works and have the information to decide if their changes lead to better outcomes or not. 
 
 **Actions to take now**
 


### PR DESCRIPTION
@sestinj & @TyDunn I think we should be declarative & use active voice where possible, using "Amplified developers" rather than "If we want developers to be amplified" for example. 

Also, added James & I. 