### PR TITLE
Fix j/k nav: stateless position, zero visual footprint

### DIFF
--- a/.continue/checks/keyboard-navigation.md
+++ b/.continue/checks/keyboard-navigation.md
@@ -39,9 +39,11 @@ Same guards, same reasons:
 
 If the easter egg's guards change, these change too.
 
-### 5. Scroll Tracking and Keyboard Stay in Sync
+### 5. Position Is Computed on Keypress, Not Tracked
 
-One `currentIndex`, written by both the IntersectionObserver and the keydown handler. If you scroll with the mouse and then press `j`, it continues from where you are. No second source of truth.
+There is no persistent `currentIndex` and no IntersectionObserver for scroll tracking. On each `j`/`k` press, the handler finds the stop closest to the scroll target line (20% from viewport top) and navigates from there. This means mouse scrolling and keyboard always agree — there's nothing to drift out of sync.
+
+BAD: An IntersectionObserver that writes to a `currentIndex` variable — when multiple stops are visible (especially near the bottom), the observer races and the index lands on the wrong stop.
 
 ### 6. Desktop Only
 

--- a/index.html
+++ b/index.html
@@ -1059,29 +1059,19 @@
       if (window.innerWidth <= 768) return;
 
       var stops = Array.from(document.querySelectorAll('.hero, .essay .section, .essay .pull-quote, .closing'));
-      var currentIndex = 0;
       var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var scrollTarget = window.innerHeight * 0.2;
 
-      // Scroll tracking — keeps currentIndex in sync with viewport
-      var navObserver = new IntersectionObserver(function(entries) {
-        entries.forEach(function(entry) {
-          if (entry.isIntersecting) {
-            var index = stops.indexOf(entry.target);
-            if (index !== -1) {
-              currentIndex = index;
-            }
-          }
-        });
-      }, {
-        rootMargin: '-20% 0px -20% 0px',
-        threshold: 0.3
-      });
+      function currentStop() {
+        var best = 0;
+        var bestDist = Infinity;
+        for (var i = 0; i < stops.length; i++) {
+          var d = Math.abs(stops[i].getBoundingClientRect().top - scrollTarget);
+          if (d < bestDist) { bestDist = d; best = i; }
+        }
+        return best;
+      }
 
-      stops.forEach(function(el) {
-        navObserver.observe(el);
-      });
-
-      // Key handler
       document.addEventListener('keydown', function(e) {
         if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
         if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -1089,16 +1079,16 @@
         var key = e.key.toLowerCase();
         if (key !== 'j' && key !== 'k') return;
 
-        if (key === 'j' && currentIndex < stops.length - 1) {
-          currentIndex++;
-        } else if (key === 'k' && currentIndex > 0) {
-          currentIndex--;
+        var index = currentStop();
+        if (key === 'j' && index < stops.length - 1) {
+          index++;
+        } else if (key === 'k' && index > 0) {
+          index--;
         } else {
           return;
         }
 
-        var rect = stops[currentIndex].getBoundingClientRect();
-        var targetY = window.pageYOffset + rect.top - (window.innerHeight * 0.2);
+        var targetY = window.pageYOffset + stops[index].getBoundingClientRect().top - scrollTarget;
         window.scrollTo({
           top: targetY,
           behavior: reducedMotion ? 'auto' : 'smooth'


### PR DESCRIPTION
## Summary
- Removes all visual feedback from j/k navigation — no indicators, no hints, no onboarding. If you know, you know.
- Fixes broken navigation near the bottom of the page by replacing the IntersectionObserver with stateless position computation on each keypress
- Rewrites the keyboard-navigation check to encode the design intent: rule 1 is "Zero Visual Footprint"

## What changed
- **Deleted**: `.nav-active` CSS, `.nav-hint` CSS, hint JS, `updateIndicator()`, IntersectionObserver scroll tracking
- **Added**: `currentStop()` function that finds the closest stop to the 20% viewport line on each keypress
- **Rewritten**: `.continue/checks/keyboard-navigation.md` — now explicitly prohibits visual feedback and observer-based tracking

## Test plan
- [ ] Press `j` repeatedly from hero through all 9 stops to closing — no skips, no stuck positions
- [ ] Press `k` from closing back to hero — same
- [ ] Scroll with mouse to the "Amplified" section near the bottom, press `j` — should go to closing, not jump elsewhere
- [ ] Press `k` from closing — should go back to the previous section
- [ ] No visible change on the page when navigating (no highlights, no hints, nothing)
- [ ] Type "amplify" — easter egg still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 9 not started · ✅ 10 no changes — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Famplified.dev%2Fpull%2F88&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->