### PR TITLE
Move hosting from Netlify to GitHub Pages

### DIFF
--- a/.continue/checks/deployment-architecture.md
+++ b/.continue/checks/deployment-architecture.md
@@ -7,13 +7,13 @@ description: Ensure changes are compatible with the static site pipeline and don
 
 ## Context
 
-This site is deployed via Netlify, which auto-detects Jekyll from the `Gemfile` and `_config.yml`, runs `jekyll build`, and serves the `_site/` output from the `main` branch. The custom domain `amplified.dev` is configured in the Netlify dashboard. There is no `netlify.toml` — everything is inferred.
+This site is deployed via GitHub Pages using the classic "Deploy from a branch" mode. GitHub Pages auto-detects Jekyll from the `Gemfile` and `_config.yml`, runs `jekyll build` (pinned via the `github-pages` gem), and serves the `_site/` output from the `main` branch. There is no GitHub Actions workflow — the build is handled entirely by GitHub Pages' native Jekyll pipeline. The custom domain `amplified.dev` is configured via the root `CNAME` file (and mirrored in the repo's Pages settings).
 
 The main page (`index.html`) is a fully standalone HTML file with inline CSS, inline JS, and no Jekyll dependencies. Jekyll merely copies it to `_site/` unchanged. The only file that uses Jekyll's markdown rendering is `supporters.md`.
 
 The image set is a mix of `.webp` (Nate's architectural pieces) and `.png` (Ty's watercolors) — all served as static files with no build-time processing.
 
-A migration to Vercel is planned, at which point the Jekyll dependency can be dropped entirely in favor of a zero-build static deploy.
+The long-term goal is a zero-build static deploy, at which point the Jekyll dependency can be dropped entirely.
 
 ## What to Check
 
@@ -59,11 +59,11 @@ BAD:
 
 ### 3. Every Push to Main Is a Production Deploy
 
-There is no staging environment or preview deploy. Every push to `main` triggers a production build on Netlify. Changes should be reviewed before merging to `main`, not after. This is especially important for image changes — a broken `og:image` reference means broken social cards immediately.
+There is no staging environment or preview deploy. Every push to `main` triggers a production build on GitHub Pages. Changes should be reviewed before merging to `main`, not after. This is especially important for image changes — a broken `og:image` reference means broken social cards immediately.
 
 ### 4. Keep the Build Minimal
 
-Don't add gems, plugins, or build steps to `Gemfile` or `_config.yml` unless they serve `supporters.md`. The goal is to eventually drop the build entirely. When the Vercel migration happens, the site should work by pointing Vercel at the repo root with no build command.
+Don't add gems, plugins, or build steps to `Gemfile` or `_config.yml` unless they serve `supporters.md`. The goal is to eventually drop the build entirely — a zero-build static deploy that serves the repo root with no build command.
 
 ### 5. Canonical URL and SEO Fundamentals
 

--- a/.continue/checks/repo-hygiene.md
+++ b/.continue/checks/repo-hygiene.md
@@ -9,7 +9,7 @@ description: The repo should only contain what the site needs. No staging direct
 
 This repo serves a single-page essay (`index.html`), a supporters list (`supporters.md` rendered by Jekyll), and a few supporting files. Everything else is either configuration, images, or discoverability files.
 
-The site used to be a GitHub Pages Jekyll project with a long-form manifesto. It's now a static site on Netlify with Jekyll only for `supporters.md`. The manifesto is gone — the essay replaced it. Remnants of the old architecture should not accumulate. When in doubt about whether a file belongs, the answer is almost always no.
+The site used to carry a long-form manifesto. It's now a mostly-static site on GitHub Pages with Jekyll only for `supporters.md`. The manifesto is gone — the essay replaced it. Remnants of the old architecture should not accumulate. When in doubt about whether a file belongs, the answer is almost always no.
 
 ## What to Check
 

--- a/.continue/checks/resist-complexity.md
+++ b/.continue/checks/resist-complexity.md
@@ -37,7 +37,7 @@ Don't extract shared CSS into a separate file "for reuse" when there are only th
 
 ### 5. The Gemfile Doesn't Grow
 
-The Gemfile exists for Jekyll, which exists for `supporters.md`. Don't add gems unless they directly serve that file. When the Vercel migration happens, the Gemfile should be deletable without affecting the main site.
+The Gemfile exists for Jekyll, which exists for `supporters.md`. Don't add gems unless they directly serve that file. When the site drops to a zero-build static deploy, the Gemfile should be deletable without affecting the main site.
 
 ## Key Files to Check
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The site is a project of [Continue](https://continue.dev). The essay speaks as a
 - **`index.html`** — The entire essay. Self-contained HTML with inline CSS and vanilla JS. No frameworks, no build step.
 - **`supporters.md`** — An open letter. Rendered by Jekyll using `_layouts/supporters.html`.
 - **`404.html`** — Custom error page.
-- **Hosted on Netlify.** Jekyll runs only to render `supporters.md`. Everything else is static.
+- **Hosted on GitHub Pages.** Jekyll runs only to render `supporters.md`. Everything else is static.
 
 ## Development
 


### PR DESCRIPTION
Moves the site's hosting from Netlify to **GitHub Pages** (classic "Deploy from a branch" mode). The `github-pages` gem is already pinned, so Pages auto-builds Jekyll natively — no Actions workflow, in keeping with the repo's minimal-build ethos.

## Changes
- **`CNAME`** — new file pinning the apex custom domain `amplified.dev` so it survives Pages rebuilds.
- **`README.md`** — "Hosted on Netlify" → "Hosted on GitHub Pages".
- **`.continue/checks/deployment-architecture.md`** — rewrote the architecture context for GitHub Pages branch-build; dropped the stale "Vercel migration planned" note.
- **`.continue/checks/repo-hygiene.md`**, **`resist-complexity.md`** — removed remaining Netlify/Vercel references.

## Not in this PR (done outside git)
- GitHub Pages settings flipped to branch-build with apex custom domain (via API).
- **DNS cutover** at the registrar — apex `A`/`AAAA` records repointed from Netlify to GitHub Pages IPs, `www` → `continuedev.github.io`. Must happen after merge, since Pages builds the `CNAME` from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)